### PR TITLE
Remove incorrect documentation.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -73,8 +73,6 @@ pub enum BroccoliError {
     Redis(#[from] redis::RedisError),
 
     /// Represents errors that occur during job processing.
-    ///
-    /// This variant can wrap any error that implements the Error trait and is Send + Sync.
     #[error("Job error: {0}")]
     Job(String),
 


### PR DESCRIPTION
The error type of BroccoliError::Job was changed to take a String in https://github.com/densumesh/broccoli/commit/7858cbdc22788bb94c78a00a9c9dd8f299484d2e but the documentation wasn't updated to reflect that.