### PR TITLE
fix: publishing messages appends to the queue last for extra robustness (surrealdb)

### DIFF
--- a/src/brokers/surrealdb/utils.rs
+++ b/src/brokers/surrealdb/utils.rs
@@ -522,7 +522,8 @@ pub(crate) async fn get_queued_transaction_impl(
                         RETURN $acc;
                     };
                     IF !$auto_ack {
-                        CREATE type::table($acc.t_) CONTENT {
+                        -- upserting will be more robust and not freeze the queue if there is a duplicate
+                        UPSERT type::table($acc.t_) CONTENT {
                             // loses the uuid, see https://github.com/surrealdb/surrealdb/issues/6104
                             //id: type::thing($acc.t_, $e.id[2]), // id[2] is the uuid
                             // we forcefully add it
@@ -623,7 +624,8 @@ async fn remove_from_queue_add_to_processed_transaction_impl(
                 // type::thing($processing_table, record::id($message_id)),
                 // we forcefully set it
                 LET $processing_id = type::record($processing_table+':u\\''+<string>record::id($message_id)+'\\'');
-                LET $c = CREATE type::table($processing_table) CONTENT {
+                -- upserting will be more robust and not freeze the queue if there is a duplicate
+                LET $c = UPSERT type::table($processing_table) CONTENT {
                     id: $processing_id,                            
                     message_id: $message_id,
                     priority: $priority,


### PR DESCRIPTION
### Summary

Previously: we appended in the queue and then we inserted the index, there was the small chance of a consumer consuming the queue but not finding the index in the consume transaction

Now: inserting the index and appending last to the queue, which means there is less risk of a race condition where we consume and the index is not there yet.

### Minor changes
Also improved error handling messages in ack transaction

### Tests

```
     Running unittests src/lib.rs (target/release/deps/broccoli_queue-cb687fcc89d05ff9)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/edge_cases.rs (target/release/deps/edge_cases-b7892b1c580d9924)

running 8 tests
test test_concurrent_consume ... ok
test test_empty_payload ... ok
test test_invalid_broker_url ... ok
test test_message_ordering ... ok
test test_multiple_batch_publish_and_consume ... ok
test test_multiple_batch_publish_and_handler ... ok
test test_ttl_not_implemented ... ok
test test_very_large_payload ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.57s

     Running tests/fairness.rs (target/release/deps/fairness-96b314741ef14cb6)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/happy_path.rs (target/release/deps/happy_path-737e9bc30ee0b476)

running 12 tests
test test_batch_publish_and_consume ... ok
test test_delayed_message ... ok
test test_message_acknowledgment ... ok
test test_message_auto_ack ... ok
test test_message_cancellation ... ok
test test_message_priority ... ok
test test_message_retry ... ok
test test_process_messages ... ok
test test_process_messages_with_handlers ... ok
test test_publish_and_consume ... ok
test test_scheduled_message ... ok
test test_try_consume_batch ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.41s

     Running tests/management.rs (target/release/deps/management-270175c472ff0622)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests broccoli_queue

running 2 tests
test src/queue.rs - queue::BroccoliQueue::process_messages (line 717) - compile ... ok
test src/queue.rs - queue::BroccoliQueue::process_messages_with_handlers (line 870) - compile ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s
```

Benchmark:
<img width="755" alt="Screenshot 2025-07-04 at 14 58 18" src="https://github.com/user-attachments/assets/8db29514-012f-4100-b039-b9f58f137c72" />

