### PR TITLE
surrealdb broker: improved performance on consume with single query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ redis = { version = "0.27.5", features = [
     "aio",
 ], optional = true }
 dashmap = "6.1.0"
-surrealdb = { version = "2.3.6", optional = true, features = ["kv-mem"] }
+surrealdb = { version = "=2.3.6", optional = true, features = ["kv-mem"] }
 chrono = { version = "0.4.41", features = ["serde"]}
 url = { version = "2.5.4", optional = true } 
 derive_more = { version = "2.0.1", features = ["display"], optional = true }

--- a/benches/surrealdb_benchmark.rs
+++ b/benches/surrealdb_benchmark.rs
@@ -139,8 +139,8 @@ where
 async fn benchmark_raw_surrealdb_throughput(db: &Surreal<Any>, message_count: usize) -> (f64, f64) {
     let queue_name = "bench_raw_surrealdb";
 
-    let index_table = format!("{queue_name}___index");
     let queue_table = format!("{queue_name}___queue");
+    let index_table = format!("{queue_name}___index");
     let processing_table = format!("{queue_name}___processing");
 
     // Generate test messages
@@ -172,7 +172,7 @@ async fn benchmark_raw_surrealdb_throughput(db: &Surreal<Any>, message_count: us
         let _: Option<BenchmarkMessageIndex> = db
             .create((index_table.clone(), id))
             .content(BenchmarkMessageIndex {
-                queue_id: queue_record_id, // queue:[timestamp,id]
+                queue_id: queue_record_id, // queue:[5,timestamp,id]
             })
             .await
             .unwrap();
@@ -458,7 +458,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     for (db, broccoli_queue, instance) in instances {
         for &count in &message_counts {
             //TODO: mem raw test runs into transaction issues so skipping it
-            // if instance == "mem" {
+            // if instance != "mem" {
             // group.bench_function(
             //     format!(
             //         "Raw surrealdb publish loop + consume loop {} - {}",

--- a/src/brokers/surrealdb/broker.rs
+++ b/src/brokers/surrealdb/broker.rs
@@ -67,7 +67,6 @@ impl Broker for SurrealDBBroker {
     /// # Returns
     /// A `Result` indicating success or failure.
     ///
-    ///
     async fn connect(&mut self, broker_url: &str) -> Result<(), BroccoliError> {
         // if the configuration contains a database connection, we prioritise that
         let db = match self.config.clone() {

--- a/src/brokers/surrealdb/utils.rs
+++ b/src/brokers/surrealdb/utils.rs
@@ -467,7 +467,7 @@ pub async fn get_queued_transaction(
             queue_name,
             auto_ack,
             batch_size,
-            "{err_msg}:'{queue_name}' tramsaction consume (removing from queue and adding to processed)",
+            "{err_msg}:'{queue_name}' transaction consume (removing from queue and adding to processed)",
         ).await;
         retryable = retryable.step(transaction).await;
     }
@@ -491,7 +491,7 @@ pub(crate) async fn get_queued_transaction_impl(
 ) -> Result<Vec<InternalBrokerMessage>, BroccoliError> {
     let queue_table = self::queue_table(queue_name);
     let processing_table = self::processing_table(queue_name);
-    let q = "
+    let q = r"
             BEGIN TRANSACTION;
             {
                 -- first of all, we  extract messages up to the batch size limit, in priority order
@@ -512,34 +512,28 @@ pub(crate) async fn get_queued_transaction_impl(
                 IF !type::is::array($msgs) OR array::is_empty($msgs) { -- nothing on the queue
                     RETURN []
                 };
-                -- next we iterate over the messages, create the in process if needed, delete and get payload
-                LET $payloads = array::fold($msgs, {out_: [], t_: $processing_table}, |$acc, $e|  {
-                    -- remove from queue and return payload
-                    -- remember we don't delete from index, instead acknowledge/reject/cancel will do it
-                    LET $deleted = DELETE ONLY $e.id RETURN BEFORE;
-                    IF !$deleted {
-                        -- if it was not deleted we will not abort the transaction, we just won't return the payload
-                        RETURN $acc;
-                    };
-                    IF !$auto_ack {
+                -- remove from the queue all in one go
+                -- remember we don't delete from index, instead acknowledge/reject/cancel will do it
+                DELETE FROM type::table($queue_table) WHERE id IN (SELECT VALUE id FROM $msgs);
+                -- next we iterate over the messages, create the in-process if needed
+                array::fold($msgs, {t_: $processing_table, auto_ack_:$auto_ack}, |$acc, $e|  {
+                    IF !$acc.auto_ack_ {
                         -- upserting will be more robust and not freeze the queue if there is a duplicate
                         UPSERT type::table($acc.t_) CONTENT {
                             // loses the uuid, see https://github.com/surrealdb/surrealdb/issues/6104
                             //id: type::thing($acc.t_, $e.id[2]), // id[2] is the uuid
                             // we forcefully add it
-                            id: type::record($acc.t_+':u\\''+<string>$e.id[2]+'\\''), // id[2] is the uuid
+                            id: type::record($acc.t_+':u\''+<string>$e.id[2]+'\''), // id[2] is the uuid
                             message_id: $e.message_id,
                             priority: $e.priority,
                             timestamp: time::now()
                         };
                     };
-                    LET $payload = SELECT * FROM ONLY $e.message_id;
-                    {out_: array::append($acc.out_, $payload), t_: $acc.t_};
+                    {t_: $acc.t_, auto_ack_: $acc.auto_ack_};
                 });
-                $payloads.out_
+                RETURN SELECT VALUE message_id.* FROM $msgs
             };
             COMMIT TRANSACTION;
-
     ";
     let result = db
         .query(q)
@@ -549,8 +543,8 @@ pub(crate) async fn get_queued_transaction_impl(
         .bind(("batch_size", batch_size))
         .await;
 
-    match result {
-        Ok(mut resp) => {
+match result {
+    Ok(mut resp) => {
             let returned: Result<
                 Vec<InternalSurrealDBBrokerMessage>,
                 surrealdb::Error,

--- a/src/brokers/surrealdb/utils.rs
+++ b/src/brokers/surrealdb/utils.rs
@@ -522,7 +522,8 @@ pub(crate) async fn get_queued_transaction_impl(
                         RETURN $acc;
                     };
                     IF !$auto_ack {
-                        CREATE type::table($acc.t_) CONTENT {
+                        -- upserting will be more robust and not freeze the queue if there is a duplicate
+                        UPSERT type::table($acc.t_) CONTENT {
                             // loses the uuid, see https://github.com/surrealdb/surrealdb/issues/6104
                             //id: type::thing($acc.t_, $e.id[2]), // id[2] is the uuid
                             // we forcefully add it
@@ -623,7 +624,8 @@ async fn remove_from_queue_add_to_processed_transaction_impl(
                 // type::thing($processing_table, record::id($message_id)),
                 // we forcefully set it
                 LET $processing_id = type::record($processing_table+':u\\''+<string>record::id($message_id)+'\\'');
-                LET $c = CREATE type::table($processing_table) CONTENT {
+                -- upserting will be more robust and not freeze the queue if there is a duplicate
+                LET $c = UPSERT type::table($processing_table) CONTENT {
                     id: $processing_id,                            
                     message_id: $message_id,
                     priority: $priority,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,3 +36,16 @@ pub async fn get_surrealdb_client() -> surrealdb::Surreal<surrealdb::engine::any
         .unwrap();
     db
 }
+
+#[cfg(all(feature = "surrealdb", test))]
+///
+pub async fn setup_queue_with(
+    sdb: surrealdb::Surreal<surrealdb::engine::any::Any>,
+) -> BroccoliQueue {
+    BroccoliQueue::builder_with(sdb)
+        .pool_connections(5)
+        .enable_scheduling(true)
+        .build()
+        .await
+        .expect("Queue setup failed. Are you sure Redis/RabbitMQ/SurrealDB is running?")
+}

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -410,7 +410,7 @@ async fn test_message_retry() {
 
     // Publish message
     #[cfg(not(feature = "test-fairness"))]
-    let published = queue
+    let _ = queue
         .publish(test_topic, None, &message, None)
         .await
         .expect("Failed to publish message");


### PR DESCRIPTION
**TL;DR** this PR brings performance improvements to the surrealdb queue implementation, we are using two queries to delete from queue and return payload (vs N queries previously)

on consume we were looping through the records and deleting/retrieving them individually, it was still within the DB context, but still had some overhead. This change moves to using just two queries for the whole payload, one to delete the queued message entries and the other query to return the payload. Thanks in advance for the review

some performance gains evidence:
<img width="951" height="508" alt="Screenshot 2025-08-18 at 10 15 44" src="https://github.com/user-attachments/assets/dd75c877-73be-4987-8967-7df54be23912" />

- cleared some code warnings
- Ran clippy

surrealdb tests
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.83s
     Running unittests src/lib.rs (debug/deps/broccoli_queue-85d2d0abc0639ceb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/edge_cases.rs (debug/deps/edge_cases-46dd8ce924dc83d5)

running 8 tests
test test_empty_payload ... ok
test test_invalid_broker_url ... ok
test test_concurrent_consume ... ok
test test_multiple_batch_publish_and_consume ... ok
test test_multiple_batch_publish_and_handler ... ok
test test_ttl_not_implemented ... ok
test test_very_large_payload ... ok
test test_message_ordering ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.15s

     Running tests/fairness.rs (debug/deps/fairness-f0d52a5e238e9873)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/happy_path.rs (debug/deps/happy_path-ce072502e7fa95df)

running 12 tests
test test_batch_publish_and_consume ... ok
test test_message_acknowledgment ... ok
test test_message_auto_ack ... ok
test test_message_cancellation ... ok
test test_message_priority ... ok
test test_message_retry ... ok
test test_process_messages ... ok
test test_process_messages_with_handlers ... ok
test test_publish_and_consume ... ok
test test_delayed_message ... ok
test test_try_consume_batch ... ok
test test_scheduled_message ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.52s

     Running tests/management.rs (debug/deps/management-561a043ed8478c2f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests broccoli_queue

running 2 tests
test src/queue.rs - queue::BroccoliQueue::process_messages (line 717) - compile ... ok
test src/queue.rs - queue::BroccoliQueue::process_messages_with_handlers (line 870) - compile ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```