### PR TITLE
feature: add `size()` function to broccoli broker. (only implemented for redis)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 tokio-util = "0.7.15"
 
 [features]
-default = []
+default = ['redis']
 redis = ["dep:bb8-redis", "dep:redis"]
 rabbitmq = ["dep:lapin", "dep:deadpool", "dep:deadpool-lapin"]
 surrealdb = ["dep:surrealdb", "dep:url"]

--- a/src/brokers/broker.rs
+++ b/src/brokers/broker.rs
@@ -124,6 +124,18 @@ pub trait Broker: Send + Sync {
     /// # Returns
     /// A `Result` indicating success or failure.
     async fn cancel(&self, queue_name: &str, message_id: String) -> Result<(), BroccoliError>;
+
+    /// Returns the size of the queue(s).
+    ///
+    /// For fairness queues, returns a map with each disambiguator queue and its size.
+    /// For unfair queues, returns a map with just the main queue name and its size.
+    ///
+    /// # Arguments
+    /// * `queue_name` - The name of the queue.
+    ///
+    /// # Returns
+    /// A `Result` containing a `HashMap<String, u64>` mapping queue names to their sizes.
+    async fn size(&self, queue_name: &str) -> Result<HashMap<String, u64>, BroccoliError>;
 }
 
 /// Configuration options for broker behavior.

--- a/src/brokers/rabbitmq/broker.rs
+++ b/src/brokers/rabbitmq/broker.rs
@@ -376,4 +376,8 @@ impl Broker for RabbitMQBroker {
     async fn cancel(&self, _queue_name: &str, _message_id: String) -> Result<(), BroccoliError> {
         Err(BroccoliError::NotImplemented)
     }
+
+    async fn size(&self, _queue_name: &str) -> Result<std::collections::HashMap<String, u64>, BroccoliError> {
+        Err(BroccoliError::NotImplemented)
+    }
 }

--- a/src/brokers/surrealdb/broker.rs
+++ b/src/brokers/surrealdb/broker.rs
@@ -489,4 +489,8 @@ impl Broker for SurrealDBBroker {
             ))),
         }
     }
+
+    async fn size(&self, _queue_name: &str) -> Result<std::collections::HashMap<String, u64>, BroccoliError> {
+        Err(BroccoliError::NotImplemented)
+    }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1060,6 +1060,29 @@ impl BroccoliQueue {
         }
     }
 
+    /// Returns the size of the queue(s).
+    ///
+    /// For fairness queues, returns a map with each disambiguator queue and its size.
+    /// For unfair queues, returns a map with just the main queue name and its size.
+    ///
+    /// # Arguments
+    /// * `queue_name` - The name of the queue.
+    ///
+    /// # Returns
+    /// A `Result` containing a `HashMap<String, u64>` mapping queue names to their sizes.
+    ///
+    /// # Errors
+    /// If the queue size fails to be retrieved, a `BroccoliError` will be returned.
+    pub async fn size(
+        &self,
+        queue_name: &str,
+    ) -> Result<std::collections::HashMap<String, u64>, BroccoliError> {
+        self.broker
+            .size(queue_name)
+            .await
+            .map_err(|e| BroccoliError::Broker(format!("Failed to get queue size: {e:?}")))
+    }
+
     /// Retrieves the status of the specified queue.
     ///
     /// # Arguments


### PR DESCRIPTION
## Description

Add a `size()` function to broccoli broker.rs. This would return a Map disambiguator's to queue.

## Test Plan

- Ran `./run-test.sh redis`. 